### PR TITLE
#106 FIX: Resolve tamanho da linha ao cadastrar 1 item

### DIFF
--- a/src/pages/equipments/EquipmentsControl.tsx
+++ b/src/pages/equipments/EquipmentsControl.tsx
@@ -361,11 +361,7 @@ function EquipmentTable() {
                         <Td />
                       </Tr>
                     </Thead>
-                    <Tbody
-                      fontWeight="semibold"
-                      maxHeight="200px"
-                      height="200px"
-                    >
+                    <Tbody fontWeight="semibold" maxHeight="200px">
                       {equipments.map((equipment) => (
                         <Tr
                           onClick={() => {

--- a/src/pages/movements/MovementControl.tsx
+++ b/src/pages/movements/MovementControl.tsx
@@ -390,11 +390,7 @@ function MovementsTable() {
                           <Td> </Td>
                         </Tr>
                       </Thead>
-                      <Tbody
-                        fontWeight="semibold"
-                        maxHeight="200px"
-                        height="200px"
-                      >
+                      <Tbody fontWeight="semibold" maxHeight="200px">
                         {movements.map((movement) => (
                           <Tr key={movement.id} cursor="pointer">
                             <Td fontWeight="medium">


### PR DESCRIPTION
## Modificações
Tamanho da linha ao cadastrar apenas 1 item.
## Descrição
Tamanho da linha ao cadastrar apenas 1 item.
## _Issue_ relacionado
 106
## Lista de controle:
- [x] Meu código segue a folha de estilos implementada
- [x] Meu _commits_ segue a política de commits do repo.
- [x] Adicionei testes para cobrir minhas modificações.
