### PR TITLE
#82 fix: toast de historico de movimentacao

### DIFF
--- a/src/components/movement-history/index.tsx
+++ b/src/components/movement-history/index.tsx
@@ -47,7 +47,7 @@ function MovementHistory({ equipmentId }: MovementHistoryProps) {
       setMovements(data);
     } catch (error) {
       setMovements([]);
-      toast.error('Nenhuma moviementacao encontrada');
+      toast.error('Erro ao buscar movimentações');
     }
   };
 


### PR DESCRIPTION
O toast de erro do histórico de movimentações da modal de equipamento estava estranhamente escrito.