### PR TITLE
114 fix: campos cadastro equipamento

### DIFF
--- a/src/components/equipment-edit-form/index.tsx
+++ b/src/components/equipment-edit-form/index.tsx
@@ -24,10 +24,8 @@ export type EditEquipFormValues = {
   situacao: string;
   model: string;
   description?: string;
-  initialUseDate: number;
   acquisitionDate: Date;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;
@@ -103,7 +101,6 @@ export default function EquipmentEditForm({
       const {
         type,
         estado,
-        initialUseDate,
         storageType,
         screenType,
         acquisitionDate,
@@ -116,7 +113,6 @@ export default function EquipmentEditForm({
       const payload = {
         type,
         estado,
-        initialUseDate,
         storageType,
         screenType,
         acquisitionDate: dateString,
@@ -196,19 +192,6 @@ export default function EquipmentEditForm({
         />
 
         <Input
-          label="Nº da Nota Fiscal"
-          errors={errors.invoiceNumber}
-          {...register('invoiceNumber', {
-            required: 'Campo Obrigatório',
-            maxLength: 50,
-            pattern: {
-              value: /^[0-9]+$/,
-              message: 'Por favor, digite apenas números.',
-            },
-          })}
-        />
-
-        <Input
           label="Tipo de aquisição"
           errors={errors.acquisition?.name}
           {...register('acquisition.name', {
@@ -227,18 +210,6 @@ export default function EquipmentEditForm({
           rules={{ required: 'Campo obrigatório', shouldUnregister: true }}
           cursor="pointer"
           defaultValue={equip?.estado}
-        />
-
-        <NewControlledSelect
-          control={control}
-          name="initialUseDate"
-          id="initialUseDate"
-          options={listOfYears}
-          placeholder="Selecione uma opção"
-          label="Ano da aquisição"
-          rules={{ required: 'Campo obrigatório', shouldUnregister: true }}
-          cursor="pointer"
-          defaultValue={equip?.initialUseDate}
         />
 
         <Datepicker

--- a/src/components/equipment-edit-modal/index.tsx
+++ b/src/components/equipment-edit-modal/index.tsx
@@ -15,9 +15,6 @@ function transformFields(data: any) {
   if (!data) return;
   const transformedData = { ...data };
 
-  transformedData.initialUseDate =
-    transformedData.initialUseDate?.split('-')?.[0];
-
   transformedData.brandName = transformedData.brand.name;
 
   transformedData.acquisitionDate = new Date(transformedData.acquisitionDate);

--- a/src/components/equipment-form/index.tsx
+++ b/src/components/equipment-form/index.tsx
@@ -22,10 +22,8 @@ type FormValues = {
   situacao: string;
   model: string;
   description?: string;
-  initialUseDate: string;
   acquisitionDate: string;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;
@@ -96,6 +94,8 @@ export default function EquipmentForm({
       watchType === 'Nobreak'
     ) {
       setDescription(`${watchModel} ${watchPower}`);
+    } else {
+      setDescription(`${watchModel}`);
     }
 
     setValue('description', description);
@@ -125,13 +125,12 @@ export default function EquipmentForm({
 
   const onSubmit = handleSubmit(async (formData) => {
     try {
-      const { type, estado, initialUseDate, storageType, screenType, ...rest } =
+      const { type, estado, storageType, screenType, ...rest } =
         formData;
 
       const payload = {
         type,
         estado,
-        initialUseDate,
         storageType,
         screenType,
         ...rest,
@@ -216,19 +215,6 @@ export default function EquipmentForm({
         />
 
         <Input
-          label="Nº da Nota Fiscal"
-          errors={errors.invoiceNumber}
-          {...register('invoiceNumber', {
-            required: 'Campo Obrigatório',
-            maxLength: 50,
-            pattern: {
-              value: /^[0-9]+$/,
-              message: 'Por favor, digite apenas números.',
-            },
-          })}
-        />
-
-        <Input
           label="Tipo de aquisição"
           errors={errors.acquisitionName}
           {...register('acquisitionName', {
@@ -244,16 +230,6 @@ export default function EquipmentForm({
           options={ESTADOS_EQUIPAMENTO}
           placeholder="Selecione uma opção"
           label="Estado do equipamento"
-          rules={{ required: 'Campo obrigatório', shouldUnregister: true }}
-        />
-
-        <NewControlledSelect
-          control={control}
-          name="initialUseDate"
-          id="initialUseDate"
-          options={listOfYears}
-          placeholder="Selecione uma opção"
-          label="Ano da aquisição"
           rules={{ required: 'Campo obrigatório', shouldUnregister: true }}
         />
 

--- a/src/components/equipment-form/index.tsx
+++ b/src/components/equipment-form/index.tsx
@@ -55,9 +55,12 @@ export default function EquipmentForm({
     handleSubmit,
     watch,
     resetField,
+    setValue,
     formState: { errors },
   } = useForm<FormValues>();
 
+  const [description, setDescription] = useState('');
+  
   const watchType = watch('type', '');
   const watchModel = watch('model', '');
   const watchPower = watch('power', '');
@@ -68,8 +71,6 @@ export default function EquipmentForm({
   const watchStorageType = watch('storageType', '');
   const watchStorageAmount = watch('storageAmount', '');
 
-  const [description, setDescription] = useState('');
-
   useEffect(() => {
     resetField('power');
     resetField('screenSize');
@@ -78,6 +79,7 @@ export default function EquipmentForm({
     resetField('processor');
     resetField('storageType');
     resetField('storageAmount');
+    resetField('description');
   }, [resetField, watchType]);
 
   useEffect(() => {
@@ -95,7 +97,11 @@ export default function EquipmentForm({
     ) {
       setDescription(`${watchModel} ${watchPower}`);
     }
+
+    setValue('description', description);
   }, [
+    setValue,
+    description,
     watchType,
     watchModel,
     watchPower,
@@ -339,10 +345,10 @@ export default function EquipmentForm({
             label="Descrição"
             errors={errors.description}
             maxChars={255}
+            defaultValue={description}
             {...register('description', {
               maxLength: 255,
             })}
-            defaultValue={description}
           />
         </GridItem>
       </Grid>

--- a/src/components/equipment-form/index.tsx
+++ b/src/components/equipment-form/index.tsx
@@ -58,7 +58,7 @@ export default function EquipmentForm({
   } = useForm<FormValues>();
 
   const [description, setDescription] = useState('');
-  
+
   const watchType = watch('type', '');
   const watchModel = watch('model', '');
   const watchPower = watch('power', '');
@@ -86,16 +86,11 @@ export default function EquipmentForm({
         `${watchModel} ${watchProcessor} ${watchRam_size} ${watchStorageType} ${watchStorageAmount}`
       );
     } else if (watchType === 'Monitor') {
-      setDescription(
-        `${watchModel} ${watchScreenType} ${watchScreenSize}`
-      );
-    } else if (
-      watchType === 'Estabilizador' ||
-      watchType === 'Nobreak'
-    ) {
-      setDescription(`${watchModel} ${watchPower}`);
+      setDescription(`${watchType} ${watchModel} ${watchScreenType} ${watchScreenSize}`);
+    } else if (watchType === 'Estabilizador' || watchType === 'Nobreak') {
+      setDescription(`${watchType} ${watchModel} ${watchPower}`);
     } else {
-      setDescription(`${watchModel}`);
+      setDescription(`${watchType} ${watchModel}`);
     }
 
     setValue('description', description);
@@ -320,10 +315,10 @@ export default function EquipmentForm({
             label="Descrição"
             errors={errors.description}
             maxChars={255}
-            defaultValue={description}
             {...register('description', {
               maxLength: 255,
             })}
+            defaultValue={description}
           />
         </GridItem>
       </Grid>

--- a/src/components/equipment-form/index.tsx
+++ b/src/components/equipment-form/index.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { useEffect } from 'react';
+import { SetStateAction, useEffect, useState } from 'react';
 import { Button, Flex, Grid, GridItem } from '@chakra-ui/react';
 import { Datepicker } from '../form-fields/date';
 
@@ -58,7 +58,17 @@ export default function EquipmentForm({
     formState: { errors },
   } = useForm<FormValues>();
 
-  const watchType = watch('type');
+  const watchType = watch('type', '');
+  const watchModel = watch('model', '');
+  const watchPower = watch('power', '');
+  const watchScreenSize = watch('screenSize', '');
+  const watchScreenType = watch('screenType', '');
+  const watchRam_size = watch('ram_size', '');
+  const watchProcessor = watch('processor', '');
+  const watchStorageType = watch('storageType', '');
+  const watchStorageAmount = watch('storageAmount', '');
+
+  const [description, setDescription] = useState('');
 
   useEffect(() => {
     resetField('power');
@@ -69,6 +79,33 @@ export default function EquipmentForm({
     resetField('storageType');
     resetField('storageAmount');
   }, [resetField, watchType]);
+
+  useEffect(() => {
+    if (watchType === 'CPU') {
+      setDescription(
+        `${watchModel} ${watchProcessor} ${watchRam_size} ${watchStorageType} ${watchStorageAmount}`
+      );
+    } else if (watchType === 'Monitor') {
+      setDescription(
+        `${watchModel} ${watchScreenType} ${watchScreenSize}`
+      );
+    } else if (
+      watchType === 'Estabilizador' ||
+      watchType === 'Nobreak'
+    ) {
+      setDescription(`${watchModel} ${watchPower}`);
+    }
+  }, [
+    watchType,
+    watchModel,
+    watchPower,
+    watchScreenSize,
+    watchScreenType,
+    watchRam_size,
+    watchProcessor,
+    watchStorageType,
+    watchStorageAmount,
+  ]);
 
   const listOfYears: Array<{ value: number; label: string }> = (() => {
     const endYear: number = new Date().getFullYear();
@@ -305,6 +342,7 @@ export default function EquipmentForm({
             {...register('description', {
               maxLength: 255,
             })}
+            defaultValue={description}
           />
         </GridItem>
       </Grid>

--- a/src/components/equipment-form/index.tsx
+++ b/src/components/equipment-form/index.tsx
@@ -86,7 +86,9 @@ export default function EquipmentForm({
         `${watchModel} ${watchProcessor} ${watchRam_size} ${watchStorageType} ${watchStorageAmount}`
       );
     } else if (watchType === 'Monitor') {
-      setDescription(`${watchType} ${watchModel} ${watchScreenType} ${watchScreenSize}`);
+      setDescription(
+        `${watchType} ${watchModel} ${watchScreenType} ${watchScreenSize}`
+      );
     } else if (watchType === 'Estabilizador' || watchType === 'Nobreak') {
       setDescription(`${watchType} ${watchModel} ${watchPower}`);
     } else {

--- a/src/components/equipment-form/index.tsx
+++ b/src/components/equipment-form/index.tsx
@@ -125,8 +125,7 @@ export default function EquipmentForm({
 
   const onSubmit = handleSubmit(async (formData) => {
     try {
-      const { type, estado, storageType, screenType, ...rest } =
-        formData;
+      const { type, estado, storageType, screenType, ...rest } = formData;
 
       const payload = {
         type,

--- a/src/components/equipment-view-form/index.tsx
+++ b/src/components/equipment-view-form/index.tsx
@@ -20,10 +20,8 @@ export type ViewEquipFormValues = {
   situacao: string;
   model: string;
   description?: string;
-  initialUseDate: string;
   acquisitionDate: Date;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;
@@ -140,15 +138,6 @@ export default function EquipmentViewForm({
         />
 
         <Input
-          disabled
-          label="Nº da Nota Fiscal"
-          errors={errors.invoiceNumber}
-          {...register('invoiceNumber')}
-          isReadOnly
-        />
-
-        <Input
-          disabled
           label="Tipo de aquisição"
           errors={errors.acquisition?.name}
           {...register('acquisition.name')}
@@ -163,16 +152,6 @@ export default function EquipmentViewForm({
           label="Estado do equipamento"
           isReadOnly
           defaultValue={equipment.estado}
-        />
-
-        <NewControlledSelect
-          control={control}
-          name="initialUseDate"
-          id="initialUseDate"
-          placeholder="Selecione uma opção"
-          label="Ano da aquisição"
-          isReadOnly
-          defaultValue={equipment.initialUseDate}
         />
 
         <Datepicker

--- a/src/components/equipment-view-form/index.tsx
+++ b/src/components/equipment-view-form/index.tsx
@@ -138,6 +138,7 @@ export default function EquipmentViewForm({
         />
 
         <Input
+          disabled
           label="Tipo de aquisição"
           errors={errors.acquisition?.name}
           {...register('acquisition.name')}

--- a/src/components/equipment-view-modal/index.tsx
+++ b/src/components/equipment-view-modal/index.tsx
@@ -17,9 +17,6 @@ function transformFields(data: any) {
   if (!data) return;
   const transformedData = { ...data };
 
-  transformedData.initialUseDate =
-    transformedData.initialUseDate.split('-')?.[0];
-
   transformedData.brandName = transformedData.brand.name;
 
   transformedData.acquisitionDate = new Date(transformedData.acquisitionDate);

--- a/src/components/form-fields/equipment/edit-equipment-form.tsx
+++ b/src/components/form-fields/equipment/edit-equipment-form.tsx
@@ -133,18 +133,6 @@ export default function EditEquipmentForm(props?: {equip: Equipment}) {
         />
         
         <Controller
-          name="initialUseDate"
-          control={control}
-          render={({ field }) => (
-            <EquipmentTextField
-              defaultValue={props?.equip.initialUseDate}
-              title="Ano de equipamento"
-              {...field}
-            />
-          )}
-        />
-        
-        <Controller
           name = "acquisitionDate"
           control={control}
           render={({ field }) => (

--- a/src/components/movement-form/index.tsx
+++ b/src/components/movement-form/index.tsx
@@ -34,9 +34,7 @@ interface equipamentData {
   model: string;
   acquisitionDate: Date;
   description?: string;
-  initialUseDate: Date;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;

--- a/src/components/movements-pdf/MovementsPdfDocument.tsx
+++ b/src/components/movements-pdf/MovementsPdfDocument.tsx
@@ -175,7 +175,9 @@ export function MovementsPDF({
           <Text style={{ ...styles.columnHeader, minWidth: 80, maxWidth: 100 }}>
             Tombamento
           </Text>
-          <Text style={{ ...styles.columnHeader, minWidth: 60, maxWidth: 80 }}>Tipo</Text>
+          <Text style={{ ...styles.columnHeader, minWidth: 60, maxWidth: 80 }}>
+            Tipo
+          </Text>
           <Text style={{ ...styles.columnHeader, maxWidth: 40 }}>Marca</Text>
           <Text style={styles.columnHeader}>Descrição</Text>
           <Text style={styles.columnHeader}>
@@ -195,7 +197,7 @@ export function MovementsPDF({
             <Text style={{ ...styles.rowData, maxWidth: 40 }}>
               {equipment?.brand?.name}
             </Text>
-            <Text style={styles.rowData}>-</Text>
+            <Text style={styles.rowData}>{equipment?.description}</Text>
             <Text style={styles.rowData}>{destination}</Text>
             <Text style={{ ...styles.rowData, maxWidth: 56 }}>
               {formattedMovementDate}

--- a/src/pages/edit-equipment/edit-equipment-modal.tsx
+++ b/src/pages/edit-equipment/edit-equipment-modal.tsx
@@ -40,10 +40,8 @@ export type Equipment = {
   brandName: string
   acquisitionName: string
   description?: string
-  initialUseDate: string
   acquisitionDate: string
   screenSize?: string
-  invoiceNumber: string
   power?: string
   screenType?: string
   processor?: string
@@ -64,10 +62,8 @@ export default function EditEquipmentModal() {
     estado: "Novo",
     model: "teste123",
     description: "teste123",
-    initialUseDate: "teste123",
     acquisitionDate: "2022-02-23",
     screenSize: "teste123",
-    invoiceNumber: "teste123",
     power: "teste123",
     screenType: "LED",
     processor: "teste123",

--- a/src/pages/equipments/EquipmentsControl.tsx
+++ b/src/pages/equipments/EquipmentsControl.tsx
@@ -50,9 +50,7 @@ export interface EquipmentData {
   model: string;
   acquisitionDate: Date;
   description?: string;
-  initialUseDate: Date;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;

--- a/src/pages/movements/MovementControl.tsx
+++ b/src/pages/movements/MovementControl.tsx
@@ -65,7 +65,7 @@ export interface movementEquipment {
   id: string;
   selected?: boolean;
   model: string;
-  description: string;
+  description?: string;
 }
 export interface movement {
   updatedAt: string | number | Date;

--- a/src/pages/movements/MovementControl.tsx
+++ b/src/pages/movements/MovementControl.tsx
@@ -65,6 +65,7 @@ export interface movementEquipment {
   id: string;
   selected?: boolean;
   model: string;
+  description: string;
 }
 export interface movement {
   updatedAt: string | number | Date;

--- a/src/services/requests/equipment/types.d.ts
+++ b/src/services/requests/equipment/types.d.ts
@@ -5,10 +5,8 @@ export interface CreateEquipmentPayload {
   situacao: string;
   model: string;
   description?: string;
-  initialUseDate: string;
   acquisitionDate: string;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;
@@ -28,10 +26,8 @@ export interface UpdateEquipmentPayload {
   situacao: string;
   model: string;
   description?: string;
-  initialUseDate: string;
   acquisitionDate: string;
   screenSize?: string;
-  invoiceNumber: string;
   power?: string;
   screenType?: string;
   processor?: string;
@@ -51,9 +47,7 @@ export interface CreateEquipmentResponse {
   estado: string;
   model: string;
   description: string;
-  initialUseDate: string;
   acquisitionDate: string;
-  invoiceNumber: string;
   type: string;
   processor?: string;
   storageAmount?: string;
@@ -89,9 +83,7 @@ export interface UpdateEquipmentResponse {
   estado: string;
   model: string;
   description: string;
-  initialUseDate: string;
   acquisitionDate: string;
-  invoiceNumber: string;
   type: string;
   processor?: string;
   storageAmount?: string;


### PR DESCRIPTION
## Modificações
* Remove os campos de `nota fiscal` e `ano de aquisição` (há um [PR dependente](https://github.com/fga-eps-mds/2023-1-Alectrion-EquipamentApi/pull/32) no EquipmentAPI)
* Adiciona informações do equipamento automaticamente no campo de descrição, durante o cadastro
    * é possível, após essa adição automática, editar o campo descrição  
    * limitação: após a primeira edição manual no campo descrição, não são mais atualizadas as infos baseadas nos campos digitados (modelo, processador, potência, etc)

## Issue Relacionada
114

