### PR TITLE
#132 fix: ajuste no getItem do token

### DIFF
--- a/src/components/equipment-view-form/index.tsx
+++ b/src/components/equipment-view-form/index.tsx
@@ -82,7 +82,7 @@ export default function EquipmentViewForm({
       const response = await api.delete('equipment/deleteEquipment', {
         params: { id: equipment.id },
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('@App:token')}`,
+          Authorization: `Bearer ${localStorage.getItem('@alectrion:token')}`,
         },
       });
 


### PR DESCRIPTION
## Modificações
Ajusta o getItem para a label do token que foi definido no login.

## Descrição
Quando a visualização de equipamento foi feita, eu precisava do token e ele ainda não estava definido. Então fiz baseado no semestre passado.
Esse fix adequa o getIem ao token atual.
Agora mudei pro token atual.