### PR TITLE
#137 FIX: Corrige data e cor da tabela de OS

### DIFF
--- a/src/constants/orderservice.ts
+++ b/src/constants/orderservice.ts
@@ -16,7 +16,7 @@ export const OSStatusStyleMap = new Map<
   ],
   [
     'CONCLUDED',
-    { color: colors.green[100], fontWeight: 'bold', fontSize: '16px' },
+    { color: colors.green[700], fontWeight: 'bold', fontSize: '16px' },
   ],
   ['WARRANTY', { color: colors.red, fontWeight: 'bold', fontSize: '16px' }],
 ]);

--- a/src/pages/order-service/OrderServiceControl.tsx
+++ b/src/pages/order-service/OrderServiceControl.tsx
@@ -55,15 +55,15 @@ export interface Equipment {
 
 export interface OrderServiceData {
   id: string;
-  date: Date;
+  date: string;
   description?: string;
   authorId: string;
   receiverName: string;
   sender?: string;
   equipmentSnapshot: any;
   senderFunctionalNumber: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
   equipment: Equipment;
   history: History;
   receiverFunctionalNumber: string;
@@ -201,6 +201,7 @@ function OrderServiceTable() {
           offset + limit
         }&${filter}`
       );
+      console.log(data);
       setNextOrderServices(data);
     } catch (error) {
       setNextOrderServices([]);
@@ -391,9 +392,9 @@ function OrderServiceTable() {
                           </Td>
 
                           <Td>
-                            {new Date(orderService.date).toLocaleDateString(
-                              'pt-BR'
-                            )}
+                            {new Date(
+                              orderService.createdAt
+                            ).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}
                           </Td>
                           <Td>
                             <IconButton

--- a/src/pages/order-service/OrderServiceControl.tsx
+++ b/src/pages/order-service/OrderServiceControl.tsx
@@ -201,7 +201,6 @@ function OrderServiceTable() {
           offset + limit
         }&${filter}`
       );
-      console.log(data);
       setNextOrderServices(data);
     } catch (error) {
       setNextOrderServices([]);


### PR DESCRIPTION
## Modificações
Adição da página de recuperação de senha;
Adição de testes na página de recuperação de senha; 

## Descrição
Corrige data inválida da tabela de OS e corrige cor do status concluido

## _Issue_ relacionado 
 137

## Como foi testado?
   - Foi realizado teste de renderização de tela.

## Lista de controle:
- [X] Meu código segue a folha de estilos implementada
- [X] Meu _commits_ segue a política de commits do repo.