### PR TITLE
FIX: Adição de lib para report de duração de teste

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "react-render-if-visible": "^2.1.1",
     "react-router-dom": "^6.6.1",
     "react-toastify": "^9.1.2",
-    "sass": "^1.57.1"
+    "sass": "^1.57.1",
+    "vitest-sonar-reporter": "^0.4.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,9 +9,9 @@ sonar.organization=fga-eps-mds-1
 
 sonar.sources=.
 sonar.exclusions=**/*.spec.tsx,**/metrics/*.py
-sonar.tests=./src,
-sonar.test.inclusions=**/*.spec.tsx,**/*.spec.ts,
-sonar.typescript.lcov.reportPaths=./coverage/lcov.info,
+sonar.tests=./src
+sonar.test.inclusions=**/*.spec.tsx,**/*.spec.ts
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.eslint.reportPaths=reports/eslint-report.json
+sonar.testExecutionReportPaths=coverage.xml
 sonar.sourceEncoding=UTF-8

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,7 @@ export default defineConfig({
     coverage: { reporter: ['lcov', 'html'] },
     environment: 'jsdom',
     setupFiles: './src/config/tests/setup-tests.ts',
+    reporters: 'vitest-sonar-reporter',
+    outputFile: 'coverage.xml',
   },
 });


### PR DESCRIPTION
Adição da lib vitest-sonar-reporter para gerar arquivo xml com duração dos testes.